### PR TITLE
Add github actions for build and release

### DIFF
--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -1,0 +1,46 @@
+---
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build_and_publish:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Get version number from tag
+        id: get_version
+        uses: battila7/get-version-action@v2
+
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v5
+        with:
+          distribution: zulu
+          java-version: 8
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Publish package to Github Packages
+        run: ./gradlew publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JAR_VERSION: ${{ steps.get_version.outputs.version-without-v  }}
+
+      - name: Create GitHub release
+        uses: marvinpinto/action-automatic-releases@latest
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          prerelease: false
+          files: |
+            build/libs/*.jar

--- a/build.gradle
+++ b/build.gradle
@@ -20,10 +20,13 @@ plugins {
     id "io.franzbecker.gradle-lombok" version "4.0.0"
     id "io.spring.dependency-management" version "1.0.11.RELEASE"
     id "org.nrg.xnat.build.xnat-data-builder" version "1.8.3"
+    id "maven-publish"
 }
 
 group "gov.ptb.qmri.xnat"
-version "1.0.0-SNAPSHOT"
+def pluginVersion = System.getenv("JAR_VERSION")
+version pluginVersion
+
 description "XNAT plugin to support ISMRMRD raw data"
 
 // This provides access to all of these repositories for dependency resolution.
@@ -240,4 +243,18 @@ task xnatPluginJar(type: Jar) {
         exclude "META-INF/*.RSA"
     }
     with jar
+}
+
+
+publishing {
+  repositories {
+    maven {
+      name = "GitHubPackages"
+      url = "https://maven.pkg.github.com/SyneRBI/xnat-mrd"
+      credentials {
+        username = System.getenv("GITHUB_ACTOR")
+        password = System.getenv("GITHUB_TOKEN")
+      }
+    }
+  }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ plugins {
     id "com.palantir.git-version" version "0.12.1"
     id "io.franzbecker.gradle-lombok" version "4.0.0"
     id "io.spring.dependency-management" version "1.0.11.RELEASE"
-    id "org.nrg.xnat.build.xnat-data-builder" version "1.8.3"
+    id "org.nrg.xnat.build.xnat-data-builder" version "${vXnat}"
     id "maven-publish"
 }
 


### PR DESCRIPTION
For https://github.com/SyneRBI/xnat-mrd/issues/7

Adds actions to (on tag push):
- Create a Github release + attach the jar to it
- Upload the jars to github packages

This is a mix of the actions from the [mirsg xnat plugin](https://github.com/UCL-MIRSG/mirsg-xnat-plugin) and the [github packages docs](https://docs.github.com/en/actions/tutorials/publish-packages/publish-java-packages-with-gradle#publishing-packages-to-github-packages). I'll need to test this by pushing a tag once it's on `main`, likely it may need some additional changes! Once everything is working on `main`, I'll make another PR to add documentation for this release workflow.