### PR TITLE
remove TEMP overwrite of coilLabel

### DIFF
--- a/python/mrd_2_xnat.py
+++ b/python/mrd_2_xnat.py
@@ -238,8 +238,6 @@ def create_final_xnat_mrd_dict(
             ckey = ckey.replace("kspace_encoding_step", "kspace_enc_step")
         xnat_mrd_dict[ckey] = get_dict_values(ismrmrd_dict, param_path)
 
-    xnat_mrd_dict["mrd:mrdScanData/acquisitionSystemInformation/coilLabelList"] = "TEMP"
-
     return xnat_mrd_dict
 
 


### PR DESCRIPTION
For https://github.com/SyneRBI/xnat-mrd/issues/28

Removes overwrite of `"mrd:mrdScanData/acquisitionSystemInformation/coilLabelList"` value with `TEMP`. I checked and the current truncation in `handle_coil_label` works correctly + matches the maximum length allowed in xnat. Increasing the size of the truncated string (even by one character) results in an error.